### PR TITLE
Fix dark mode colors and keyboard handling on deck/card edit screens

### DIFF
--- a/front/app/flashcards/cardEdit.tsx
+++ b/front/app/flashcards/cardEdit.tsx
@@ -3,6 +3,9 @@ import {
   View,
   TextInput,
   Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
 } from "react-native";
 import { useRouter, useLocalSearchParams } from "expo-router";
 import { ThemedText } from "@/components/ThemedText";
@@ -88,36 +91,46 @@ export default function CardEdit() {
 
   return (
     <ThemedView style={styles.container}>
-      <View style={styles.content}>
-        <ThemedText style={styles.label}>Front (question)</ThemedText>
-        <TextInput
-          style={[styles.input, styles.cardInput]}
-          placeholder="Enter the question or term"
-          placeholderTextColor="#888"
-          value={cardFront}
-          onChangeText={setCardFront}
-          multiline
-        />
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.content}>
+            <ThemedText style={styles.label}>Front (question)</ThemedText>
+            <TextInput
+              style={[styles.input, styles.cardInput]}
+              placeholder="Enter the question or term"
+              placeholderTextColor="#888"
+              value={cardFront}
+              onChangeText={setCardFront}
+              multiline
+            />
 
-        <ThemedText style={styles.label}>Back (answer)</ThemedText>
-        <TextInput
-          style={[styles.input, styles.cardInput]}
-          placeholder="Enter the answer or definition"
-          placeholderTextColor="#888"
-          value={cardBack}
-          onChangeText={setCardBack}
-          multiline
-        />
+            <ThemedText style={styles.label}>Back (answer)</ThemedText>
+            <TextInput
+              style={[styles.input, styles.cardInput]}
+              placeholder="Enter the answer or definition"
+              placeholderTextColor="#888"
+              value={cardBack}
+              onChangeText={setCardBack}
+              multiline
+            />
 
-        <View style={styles.buttons}>
-          <PlatformPressable style={styles.deleteButton} onPress={handleDelete}>
-            <ThemedText style={styles.deleteButtonText}>Delete</ThemedText>
-          </PlatformPressable>
-          <PlatformPressable style={styles.saveButton} onPress={handleSave}>
-            <ThemedText style={styles.saveButtonText}>Save</ThemedText>
-          </PlatformPressable>
-        </View>
-      </View>
+            <View style={styles.buttons}>
+              <PlatformPressable style={styles.deleteButton} onPress={handleDelete}>
+                <ThemedText style={styles.deleteButtonText}>Delete</ThemedText>
+              </PlatformPressable>
+              <PlatformPressable style={styles.saveButton} onPress={handleSave}>
+                <ThemedText style={styles.saveButtonText}>Save</ThemedText>
+              </PlatformPressable>
+            </View>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
     </ThemedView>
   );
 }
@@ -125,6 +138,12 @@ export default function CardEdit() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  flex: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
   },
   content: {
     flex: 1,

--- a/front/app/flashcards/deck.tsx
+++ b/front/app/flashcards/deck.tsx
@@ -12,6 +12,7 @@ import {
 } from "react-native";
 import { useFocusEffect, useRouter, useLocalSearchParams, useNavigation } from "expo-router";
 import { useLayoutEffect } from "react";
+import type { StackNavigationProp } from "@react-navigation/stack";
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
 import { IconSymbol } from "@/components/ui/IconSymbol";
@@ -49,7 +50,12 @@ export default function DeckDetail() {
   const tintColor = useThemeColor({}, "tint");
   const cardBackground = useThemeColor({}, "cardBackground");
 
-  const navigation = useNavigation();
+  type FlashcardsParamList = {
+    "flashcards/deck": { deckId: string };
+    "flashcards/study": { deckId: string; title?: string };
+    "flashcards/cardEdit": { deckId: string; flashcardId: string; front: string; back: string };
+  };
+  const navigation = useNavigation<StackNavigationProp<FlashcardsParamList, "flashcards/deck">>();
 
   const refresh = useCallback(async () => {
     if (!deckId) {
@@ -84,6 +90,7 @@ export default function DeckDetail() {
   );
 
   useLayoutEffect(() => {
+    if (!navigation.isFocused()) return;
     if (showAddCard) {
       navigation.setOptions({ title: "Add New Card" });
     } else if (isEditing) {

--- a/front/app/flashcards/deck.tsx
+++ b/front/app/flashcards/deck.tsx
@@ -6,6 +6,9 @@ import {
   ActivityIndicator,
   TextInput,
   Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
 } from "react-native";
 import { useFocusEffect, useRouter, useLocalSearchParams } from "expo-router";
 import { ThemedText } from "@/components/ThemedText";
@@ -24,6 +27,7 @@ import {
   Flashcard,
 } from "@/api/flashcards";
 import { PlatformPressable } from "@react-navigation/elements";
+import { useThemeColor } from "@/hooks/useThemeColor";
 
 export default function DeckDetail() {
   const router = useRouter();
@@ -38,6 +42,11 @@ export default function DeckDetail() {
   const [showAddCard, setShowAddCard] = useState(false);
   const [newCardFront, setNewCardFront] = useState("");
   const [newCardBack, setNewCardBack] = useState("");
+  const borderColor = useThemeColor({}, "border");
+  const textColor = useThemeColor({}, "text");
+  const iconColor = useThemeColor({}, "icon");
+  const tintColor = useThemeColor({}, "tint");
+  const cardBackground = useThemeColor({}, "cardBackground");
 
   const refresh = useCallback(async () => {
     if (!deckId) {
@@ -187,40 +196,50 @@ export default function DeckDetail() {
   if (showAddCard) {
     return (
       <ThemedView style={styles.container}>
-        <View style={styles.modalContainer}>
-          <ThemedText style={styles.modalTitle}>Add New Card</ThemedText>
-          <TextInput
-            style={[styles.input, styles.cardInput]}
-            placeholder="Front (question)"
-            placeholderTextColor="#888"
-            value={newCardFront}
-            onChangeText={setNewCardFront}
-            multiline
-          />
-          <TextInput
-            style={[styles.input, styles.cardInput]}
-            placeholder="Back (answer)"
-            placeholderTextColor="#888"
-            value={newCardBack}
-            onChangeText={setNewCardBack}
-            multiline
-          />
-          <View style={styles.modalButtons}>
-            <PlatformPressable
-              style={styles.cancelButton}
-              onPress={() => {
-                setShowAddCard(false);
-                setNewCardFront("");
-                setNewCardBack("");
-              }}
-            >
-              <ThemedText style={styles.cancelButtonText}>Cancel</ThemedText>
-            </PlatformPressable>
-            <PlatformPressable style={styles.saveButton} onPress={handleAddCard}>
-              <ThemedText style={styles.saveButtonText}>Add</ThemedText>
-            </PlatformPressable>
-          </View>
-        </View>
+        <KeyboardAvoidingView
+          style={styles.flex}
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+        >
+          <ScrollView
+            contentContainerStyle={styles.scrollContent}
+            keyboardShouldPersistTaps="handled"
+          >
+            <View style={styles.modalContainer}>
+              <ThemedText style={styles.modalTitle}>Add New Card</ThemedText>
+              <TextInput
+                style={[styles.input, styles.cardInput, { borderColor, color: textColor }]}
+                placeholder="Front (question)"
+                placeholderTextColor={iconColor}
+                value={newCardFront}
+                onChangeText={setNewCardFront}
+                multiline
+              />
+              <TextInput
+                style={[styles.input, styles.cardInput, { borderColor, color: textColor }]}
+                placeholder="Back (answer)"
+                placeholderTextColor={iconColor}
+                value={newCardBack}
+                onChangeText={setNewCardBack}
+                multiline
+              />
+              <View style={styles.modalButtons}>
+                <PlatformPressable
+                  style={[styles.cancelButton, { backgroundColor: cardBackground }]}
+                  onPress={() => {
+                    setShowAddCard(false);
+                    setNewCardFront("");
+                    setNewCardBack("");
+                  }}
+                >
+                  <ThemedText style={styles.cancelButtonText}>Cancel</ThemedText>
+                </PlatformPressable>
+                <PlatformPressable style={[styles.saveButton, { backgroundColor: tintColor }]} onPress={handleAddCard}>
+                  <ThemedText style={styles.saveButtonText}>Add</ThemedText>
+                </PlatformPressable>
+              </View>
+            </View>
+          </ScrollView>
+        </KeyboardAvoidingView>
       </ThemedView>
     );
   }
@@ -228,54 +247,64 @@ export default function DeckDetail() {
   if (isEditing) {
     return (
       <ThemedView style={styles.container}>
-        <View style={styles.modalContainer}>
-          <ThemedText style={styles.modalTitle}>Edit Deck</ThemedText>
-          <TextInput
-            style={styles.input}
-            placeholder="Deck name"
-            placeholderTextColor="#888"
-            value={editName}
-            onChangeText={setEditName}
-          />
-          <TextInput
-            style={[styles.input, styles.descriptionInput]}
-            placeholder="Description"
-            placeholderTextColor="#888"
-            value={editDescription}
-            onChangeText={setEditDescription}
-            multiline
-          />
-          <View style={styles.modalButtons}>
-            <PlatformPressable
-              style={styles.cancelButton}
-              onPress={() => {
-                setIsEditing(false);
-                setEditName(deck?.name || "");
-                setEditDescription(deck?.description || "");
-              }}
-            >
-              <ThemedText style={styles.cancelButtonText}>Cancel</ThemedText>
-            </PlatformPressable>
-            <PlatformPressable style={styles.saveButton} onPress={handleSaveDeck}>
-              <ThemedText style={styles.saveButtonText}>Save</ThemedText>
-            </PlatformPressable>
-          </View>
-        </View>
+        <KeyboardAvoidingView
+          style={styles.flex}
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+        >
+          <ScrollView
+            contentContainerStyle={styles.scrollContent}
+            keyboardShouldPersistTaps="handled"
+          >
+            <View style={styles.modalContainer}>
+              <ThemedText style={styles.modalTitle}>Edit Deck</ThemedText>
+              <TextInput
+                style={[styles.input, { borderColor, color: textColor }]}
+                placeholder="Deck name"
+                placeholderTextColor={iconColor}
+                value={editName}
+                onChangeText={setEditName}
+              />
+              <TextInput
+                style={[styles.input, styles.descriptionInput, { borderColor, color: textColor }]}
+                placeholder="Description"
+                placeholderTextColor={iconColor}
+                value={editDescription}
+                onChangeText={setEditDescription}
+                multiline
+              />
+              <View style={styles.modalButtons}>
+                <PlatformPressable
+                  style={[styles.cancelButton, { backgroundColor: cardBackground }]}
+                  onPress={() => {
+                    setIsEditing(false);
+                    setEditName(deck?.name || "");
+                    setEditDescription(deck?.description || "");
+                  }}
+                >
+                  <ThemedText style={styles.cancelButtonText}>Cancel</ThemedText>
+                </PlatformPressable>
+                <PlatformPressable style={[styles.saveButton, { backgroundColor: tintColor }]} onPress={handleSaveDeck}>
+                  <ThemedText style={styles.saveButtonText}>Save</ThemedText>
+                </PlatformPressable>
+              </View>
+            </View>
+          </ScrollView>
+        </KeyboardAvoidingView>
       </ThemedView>
     );
   }
 
   return (
     <ThemedView style={styles.container}>
-      <View style={styles.header}>
+      <View style={[styles.header, { borderBottomColor: borderColor }]}>
         <PlatformPressable style={styles.headerButton} onPress={() => setIsEditing(true)}>
-          <IconSymbol name="pencil" size={20} color="#666" />
+          <IconSymbol name="pencil" size={20} color={iconColor} />
         </PlatformPressable>
         <PlatformPressable style={styles.headerButton} onPress={handleDeleteDeck}>
           <IconSymbol name="trash" size={20} color="#d33" />
         </PlatformPressable>
         <PlatformPressable
-          style={[styles.studyButton]}
+          style={[styles.studyButton, { backgroundColor: tintColor }]}
           onPress={handleStudyPress}
         >
           <ThemedText style={styles.studyButtonText}>Study</ThemedText>
@@ -283,10 +312,10 @@ export default function DeckDetail() {
       </View>
 
       {deck?.description ? (
-        <ThemedText style={styles.description}>{deck.description}</ThemedText>
+        <ThemedText style={[styles.description, { color: iconColor }]}>{deck.description}</ThemedText>
       ) : null}
 
-      <PlatformPressable style={styles.fab} onPress={() => setShowAddCard(true)}>
+      <PlatformPressable style={[styles.fab, { backgroundColor: tintColor }]} onPress={() => setShowAddCard(true)}>
         <IconSymbol name="plus" color="white"></IconSymbol>
       </PlatformPressable>
 
@@ -299,7 +328,7 @@ export default function DeckDetail() {
         }
         renderItem={({ item, index }) => (
           <PlatformPressable
-            style={styles.cardItem}
+            style={[styles.cardItem, { borderBottomColor: borderColor }]}
             onPress={() =>
               router.push({
                 pathname: "/flashcards/cardEdit",
@@ -313,7 +342,7 @@ export default function DeckDetail() {
             }
             onLongPress={() => handleDeleteCard(item)}
           >
-            <ThemedText style={styles.cardNumber}>#{index + 1}</ThemedText>
+            <ThemedText style={[styles.cardNumber, { color: iconColor }]}>#{index + 1}</ThemedText>
             <ThemedText style={styles.cardFront} numberOfLines={2}>
               {item.front}
             </ThemedText>
@@ -321,8 +350,8 @@ export default function DeckDetail() {
         )}
         ListEmptyComponent={
           <View style={styles.emptyContainer}>
-            <ThemedText style={styles.emptyText}>No cards yet</ThemedText>
-            <ThemedText style={styles.emptySubtext}>
+            <ThemedText style={[styles.emptyText, { color: iconColor }]}>No cards yet</ThemedText>
+            <ThemedText style={[styles.emptySubtext, { color: iconColor }]}>
               Tap + to add your first card
             </ThemedText>
           </View>
@@ -336,19 +365,23 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
+  flex: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+  },
   header: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
     padding: 12,
     borderBottomWidth: 1,
-    borderBottomColor: "#ccc",
   },
   headerButton: {
     padding: 8,
   },
   studyButton: {
-    backgroundColor: "#03465b",
     paddingHorizontal: 16,
     paddingVertical: 8,
     borderRadius: 8,
@@ -359,7 +392,6 @@ const styles = StyleSheet.create({
   },
   description: {
     fontSize: 14,
-    color: "#666",
     padding: 12,
     paddingTop: 0,
   },
@@ -371,12 +403,10 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     padding: 12,
     borderBottomWidth: 1,
-    borderBottomColor: "#ccc",
     alignItems: "center",
   },
   cardNumber: {
     fontSize: 14,
-    color: "#888",
     marginRight: 12,
     width: 30,
   },
@@ -388,7 +418,6 @@ const styles = StyleSheet.create({
     position: "absolute",
     bottom: 30,
     right: 30,
-    backgroundColor: "#03465b",
     width: 60,
     height: 60,
     borderRadius: 30,
@@ -410,11 +439,9 @@ const styles = StyleSheet.create({
   },
   emptyText: {
     fontSize: 18,
-    color: "#888",
   },
   emptySubtext: {
     fontSize: 14,
-    color: "#666",
     marginTop: 8,
   },
   modalContainer: {
@@ -430,7 +457,6 @@ const styles = StyleSheet.create({
   },
   input: {
     borderWidth: 1,
-    borderColor: "#ccc",
     borderRadius: 8,
     padding: 12,
     fontSize: 16,
@@ -454,7 +480,6 @@ const styles = StyleSheet.create({
     padding: 12,
     marginRight: 10,
     borderRadius: 8,
-    backgroundColor: "#ccc",
     alignItems: "center",
   },
   cancelButtonText: {
@@ -466,7 +491,6 @@ const styles = StyleSheet.create({
     padding: 12,
     marginLeft: 10,
     borderRadius: 8,
-    backgroundColor: "#03465b",
     alignItems: "center",
   },
   saveButtonText: {

--- a/front/app/flashcards/deck.tsx
+++ b/front/app/flashcards/deck.tsx
@@ -10,7 +10,8 @@ import {
   Platform,
   ScrollView,
 } from "react-native";
-import { useFocusEffect, useRouter, useLocalSearchParams } from "expo-router";
+import { useFocusEffect, useRouter, useLocalSearchParams, useNavigation } from "expo-router";
+import { useLayoutEffect } from "react";
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
 import { IconSymbol } from "@/components/ui/IconSymbol";
@@ -48,6 +49,8 @@ export default function DeckDetail() {
   const tintColor = useThemeColor({}, "tint");
   const cardBackground = useThemeColor({}, "cardBackground");
 
+  const navigation = useNavigation();
+
   const refresh = useCallback(async () => {
     if (!deckId) {
       Sentry.captureException(new Error("refresh called with missing deckId"));
@@ -79,6 +82,16 @@ export default function DeckDetail() {
       refresh();
     }, [refresh])
   );
+
+  useLayoutEffect(() => {
+    if (showAddCard) {
+      navigation.setOptions({ title: "Add New Card" });
+    } else if (isEditing) {
+      navigation.setOptions({ title: "Edit Deck" });
+    } else {
+      navigation.setOptions({ title: deck?.name || "" });
+    }
+  }, [showAddCard, isEditing, deck?.name, navigation]);
 
   const handleSaveDeck = async () => {
     if (!editName.trim()) {
@@ -205,7 +218,6 @@ export default function DeckDetail() {
             keyboardShouldPersistTaps="handled"
           >
             <View style={styles.modalContainer}>
-              <ThemedText style={styles.modalTitle}>Add New Card</ThemedText>
               <TextInput
                 style={[styles.input, styles.cardInput, { borderColor, color: textColor }]}
                 placeholder="Front (question)"
@@ -256,7 +268,6 @@ export default function DeckDetail() {
             keyboardShouldPersistTaps="handled"
           >
             <View style={styles.modalContainer}>
-              <ThemedText style={styles.modalTitle}>Edit Deck</ThemedText>
               <TextInput
                 style={[styles.input, { borderColor, color: textColor }]}
                 placeholder="Deck name"
@@ -448,12 +459,6 @@ const styles = StyleSheet.create({
     flex: 1,
     padding: 20,
     justifyContent: "center",
-  },
-  modalTitle: {
-    fontSize: 20,
-    fontWeight: "bold",
-    marginBottom: 20,
-    textAlign: "center",
   },
   input: {
     borderWidth: 1,


### PR DESCRIPTION
## Summary
- Replaced hardcoded colors with theme-aware `useThemeColor()` values in `deck.tsx` so borders, text, icons, buttons, and backgrounds adapt to light/dark mode
- Wrapped "Add New Card", "Edit Deck", and card edit forms in `KeyboardAvoidingView` + `ScrollView` so the keyboard doesn't cover inputs
- Applied same keyboard fix to `cardEdit.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic screen titles that reflect current deck editing actions

* **Bug Fixes**
  * Improved keyboard behavior when editing flashcards on mobile devices

* **Style**
  * Enhanced theme color consistency throughout the app interface

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tpaulshippy/bots/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->