### PR TITLE
fix: replace hamburger menu with back button on chat screen

### DIFF
--- a/front/app/_layout.tsx
+++ b/front/app/_layout.tsx
@@ -250,7 +250,7 @@ export default function RootLayout() {
               headerTintColor: textColor,
               headerLeft: () => (
                 <PlatformPressable
-                  onPress={() => router.push("/chatHistory")}
+                  onPress={() => router.replace("/chatHistory")}
                 >
                   <IconSymbol
                     name="chevron.backward"

--- a/front/app/_layout.tsx
+++ b/front/app/_layout.tsx
@@ -250,10 +250,10 @@ export default function RootLayout() {
               headerTintColor: textColor,
               headerLeft: () => (
                 <PlatformPressable
-                  onPress={() => setIsDrawerOpen(true)}
+                  onPress={() => router.push("/chatHistory")}
                 >
                   <IconSymbol
-                    name="line.3.horizontal"
+                    name="chevron.backward"
                     color={iconColor}
                     size={40}
                     style={styles.menuIcon}


### PR DESCRIPTION
## Summary
- Replace the hamburger menu icon with a back chevron on the chat screen header
- Back button navigates to `/chatHistory` (the chat list)
- Hamburger menu remains on `chatHistory`, `flashcards`, and index screens

## Changes
`front/app/_layout.tsx`: Changed the `chat` Stack.Screen `headerLeft` from `line.3.horizontal` (hamburger) with `setIsDrawerOpen(true)` to `chevron.backward` with `router.push("/chatHistory")`.