### PR TITLE
Add web search toggle to bot editors and system prompt injection

### DIFF
--- a/front/api/botTemplates.ts
+++ b/front/api/botTemplates.ts
@@ -66,9 +66,6 @@ export const generateSystemPrompt = (bot: Bot, inputs: Record<string, string>) =
         prompt += "\n\n";
     }
     if (bot.enable_web_search) {
-        if (prompt) {
-            prompt += "\n\n";
-        }
         prompt += "You may use the web_search tool to look up current information. Use it when you need to find up-to-date facts, recent events, or information beyond your training data.";
         prompt += "\n\n";
     }

--- a/front/api/botTemplates.ts
+++ b/front/api/botTemplates.ts
@@ -65,5 +65,9 @@ export const generateSystemPrompt = (bot: Bot, inputs: Record<string, string>) =
         prompt += "Always avoid discussing adult topics.";
         prompt += "\n\n";
     }
+    if (bot.enable_web_search) {
+        prompt += "You have the ability to search the web for current information. Use the web search tool whenever you need to find up-to-date facts, recent events, or information beyond your training data.";
+        prompt += "\n\n";
+    }
     return prompt;
 };

--- a/front/api/botTemplates.ts
+++ b/front/api/botTemplates.ts
@@ -66,7 +66,10 @@ export const generateSystemPrompt = (bot: Bot, inputs: Record<string, string>) =
         prompt += "\n\n";
     }
     if (bot.enable_web_search) {
-        prompt += "You have the ability to search the web for current information. Use the web search tool whenever you need to find up-to-date facts, recent events, or information beyond your training data.";
+        if (prompt) {
+            prompt += "\n\n";
+        }
+        prompt += "You may use the web_search tool to look up current information. Use it when you need to find up-to-date facts, recent events, or information beyond your training data.";
         prompt += "\n\n";
     }
     return prompt;

--- a/front/app/parent/botAdvanced.tsx
+++ b/front/app/parent/botAdvanced.tsx
@@ -1,4 +1,4 @@
-import { Modal, Platform, StyleSheet } from "react-native";
+import { Modal, Platform, StyleSheet, Switch } from "react-native";
 import alert from "@/components/Alert";
 import { ThemedText } from "@/components/ThemedText";
 import { ThemedView } from "@/components/ThemedView";
@@ -13,7 +13,6 @@ import { IconSymbol } from "@/components/ui/IconSymbol";
 import { PlatformPressable } from "@react-navigation/elements";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { AiModel, fetchAiModels } from "@/api/aiModels";
-import { Switch } from "react-native";
 import * as Sentry from "@sentry/react-native";
 
 interface AdvancedBotEditorProps {

--- a/front/app/parent/botAdvanced.tsx
+++ b/front/app/parent/botAdvanced.tsx
@@ -13,6 +13,7 @@ import { IconSymbol } from "@/components/ui/IconSymbol";
 import { PlatformPressable } from "@react-navigation/elements";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { AiModel, fetchAiModels } from "@/api/aiModels";
+import { Switch } from "react-native";
 import * as Sentry from "@sentry/react-native";
 
 interface AdvancedBotEditorProps {
@@ -29,6 +30,7 @@ export default function AdvancedBotEditor({
   const [modelMissing, setModelMissing] = useState(false);
   const [isPickerVisible, setPickerVisible] = useState(false);
   const iconColor = useThemeColor({}, "tint");
+  const bgColor = useThemeColor({}, "cardBackground");
   const buttonIconColor = useThemeColor({}, "text");
   const [aiModels, setAiModels] = useState<AiModel[]>([]);
 
@@ -156,6 +158,20 @@ export default function AdvancedBotEditor({
         />
       </ThemedView>
 
+      <ThemedView
+        style={[styles.formGroupCheckbox, { backgroundColor: bgColor }]}
+      >
+        <ThemedText style={styles.checkboxLabel}>
+          Enable Web Search
+        </ThemedText>
+        <Switch
+          value={bot.enable_web_search}
+          onValueChange={(value) =>
+            setBot({ ...bot, enable_web_search: value })
+          }
+        />
+      </ThemedView>
+
       <ThemedView style={styles.buttons}>
         <ThemedButton onPress={() => deleteBot()} style={styles.button}>
           <IconSymbol
@@ -184,6 +200,20 @@ const styles = StyleSheet.create({
   formGroup: {
     width: "100%",
     marginBottom: 15,
+  },
+  formGroupCheckbox: {
+    width: "100%",
+    marginBottom: 15,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    borderRadius: 10,
+    padding: 5,
+  },
+  checkboxLabel: {
+    fontSize: 16,
+    marginBottom: 5,
+    marginLeft: 10,
   },
   label: {
     fontSize: 16,

--- a/front/app/parent/botSimple.tsx
+++ b/front/app/parent/botSimple.tsx
@@ -86,6 +86,7 @@ export default function SimpleBotEditor({
     bot.response_length,
     bot.restrict_language,
     bot.restrict_adult_topics,
+    bot.enable_web_search,
     inputs,
   ]);
 


### PR DESCRIPTION
## Summary
- Add Enable Web Search toggle to advanced bot editor (was only available in simple editor)
- When enabled in simple editor, append web search instruction to the generated system prompt so the LLM knows to use the web search tool
- Fix missing `enable_web_search` in useEffect dependency array in simple editor